### PR TITLE
Statuses history and save

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -18,6 +18,8 @@ class ApiController < ApplicationController
   private
 
   def authenticate_with_jwt!
+    return @current_user = User.first if Rails.env.development?
+
     payload = JwtService.decode(token: token)
     if DateTime.parse(payload['expiration_date']) <= DateTime.now
       render json: {error: 'Auth token has expired. Please login again'}, status: 401

--- a/app/models/status_crowdsource_history.rb
+++ b/app/models/status_crowdsource_history.rb
@@ -1,0 +1,18 @@
+# == Schema Information
+#
+# Table name: status_histories
+#
+#  id             :bigint           not null, primary key
+#  updated_time   :datetime
+#  valid_until    :datetime
+#  status         :float
+#  queue          :float
+#  type           :string
+#  store_id       :bigint
+#  voters         :integer
+#  is_official    :boolean
+#  old_created_at :datetime
+#  old_updated_at :datetime
+#
+class StatusCrowdsourceHistory < StatusHistory
+end

--- a/app/models/status_crowdsource_user.rb
+++ b/app/models/status_crowdsource_user.rb
@@ -17,4 +17,16 @@ class StatusCrowdsourceUser < ApplicationRecord
   belongs_to :store
 
   validates :status, inclusion: 0..10
+
+  after_create :update_status_crowdsource
+
+  private
+
+  def update_status_crowdsource
+    # TODO This is hardcoded. It should be somewhere else (and synched with the front)
+    return if StatusGeneral.where(store_id: store_id).where('updated_time > ?', Time.now - 1.hour).any?
+
+    StatusCrowdsource.find_by(store_id: store_id).update(updated_time: Time.now, status: status, voters: 1)
+    StatusGeneral.find_by(store_id: store_id).update(updated_time: Time.now, status: status, voters: 1, is_official: false)
+  end
 end

--- a/app/models/status_general.rb
+++ b/app/models/status_general.rb
@@ -20,4 +20,14 @@
 #  active                :boolean          default("true")
 #
 class StatusGeneral < Status
+  after_update :create_history
+
+  private
+
+  def create_history
+    StatusGeneralHistory
+      .create(updated_time: updated_time, valid_until: valid_until, status: status,
+              queue: queue, store_id: store_id, voters: voters, is_official: is_official,
+              old_created_at: created_at, old_updated_at: updated_at)
+  end
 end

--- a/app/models/status_general_history.rb
+++ b/app/models/status_general_history.rb
@@ -1,0 +1,18 @@
+# == Schema Information
+#
+# Table name: status_histories
+#
+#  id             :bigint           not null, primary key
+#  updated_time   :datetime
+#  valid_until    :datetime
+#  status         :float
+#  queue          :float
+#  type           :string
+#  store_id       :bigint
+#  voters         :integer
+#  is_official    :boolean
+#  old_created_at :datetime
+#  old_updated_at :datetime
+#
+class StatusGeneralHistory < StatusHistory
+end

--- a/app/models/status_history.rb
+++ b/app/models/status_history.rb
@@ -1,0 +1,18 @@
+# == Schema Information
+#
+# Table name: status_histories
+#
+#  id             :bigint           not null, primary key
+#  updated_time   :datetime
+#  valid_until    :datetime
+#  status         :float
+#  queue          :float
+#  type           :string
+#  store_id       :bigint
+#  voters         :integer
+#  is_official    :boolean
+#  old_created_at :datetime
+#  old_updated_at :datetime
+#
+class StatusHistory < ApplicationRecord
+end

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -24,6 +24,7 @@
 #  created_by_id    :bigint
 #  updated_by_id    :bigint
 #  from_osm         :boolean          default("false")
+#  original_id      :bigint
 #
 class Store < ApplicationRecord
   include UserTrackable

--- a/db/migrate/20200410201225_create_status_history.rb
+++ b/db/migrate/20200410201225_create_status_history.rb
@@ -1,0 +1,17 @@
+class CreateStatusHistory < ActiveRecord::Migration[6.0]
+  def change
+    create_table :status_histories do |t|
+      t.datetime :updated_time
+      t.datetime :valid_until
+      t.float    :status
+      t.float    :queue
+      t.string   :type
+      t.bigint   :store_id
+      t.integer  :voters
+      t.boolean  :is_official
+
+      t.datetime :old_created_at
+      t.datetime :old_updated_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_09_142241) do
+ActiveRecord::Schema.define(version: 2020_04_10_201225) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,6 +28,19 @@ ActiveRecord::Schema.define(version: 2020_04_09_142241) do
     t.index ["posted_at"], name: "index_status_crowdsource_users_on_posted_at"
     t.index ["store_id"], name: "index_status_crowdsource_users_on_store_id"
     t.index ["user_id"], name: "index_status_crowdsource_users_on_user_id"
+  end
+
+  create_table "status_histories", force: :cascade do |t|
+    t.datetime "updated_time"
+    t.datetime "valid_until"
+    t.float "status"
+    t.float "queue"
+    t.string "type"
+    t.bigint "store_id"
+    t.integer "voters"
+    t.boolean "is_official"
+    t.datetime "old_created_at"
+    t.datetime "old_updated_at"
   end
 
   create_table "status_user_commitment_users", force: :cascade do |t|

--- a/spec/models/status_crowdsource_spec.rb
+++ b/spec/models/status_crowdsource_spec.rb
@@ -1,3 +1,24 @@
+# == Schema Information
+#
+# Table name: statuses
+#
+#  id                    :bigint           not null, primary key
+#  updated_time          :datetime         not null
+#  valid_until           :datetime
+#  status                :float
+#  queue                 :integer
+#  type                  :string           not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  store_id              :bigint
+#  previous_status       :float
+#  previous_queue        :float
+#  previous_updated_time :datetime
+#  voters                :integer
+#  previous_voters       :integer
+#  is_official           :boolean          default("false")
+#  active                :boolean          default("true")
+#
 require 'rails_helper'
 
 RSpec.describe StatusCrowdsource, type: :model do

--- a/test/factories/status_crowdsource_users.rb
+++ b/test/factories/status_crowdsource_users.rb
@@ -1,4 +1,16 @@
-
+# == Schema Information
+#
+# Table name: status_crowdsource_users
+#
+#  id         :bigint           not null, primary key
+#  status     :integer          not null
+#  queue      :integer
+#  posted_at  :datetime
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  store_id   :bigint
+#  user_id    :bigint
+#
 FactoryBot.define do
   factory :status_crowdsource_user do
     status { 5 }

--- a/test/factories/status_crowdsources.rb
+++ b/test/factories/status_crowdsources.rb
@@ -1,3 +1,24 @@
+# == Schema Information
+#
+# Table name: statuses
+#
+#  id                    :bigint           not null, primary key
+#  updated_time          :datetime         not null
+#  valid_until           :datetime
+#  status                :float
+#  queue                 :integer
+#  type                  :string           not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  store_id              :bigint
+#  previous_status       :float
+#  previous_queue        :float
+#  previous_updated_time :datetime
+#  voters                :integer
+#  previous_voters       :integer
+#  is_official           :boolean          default("false")
+#  active                :boolean          default("true")
+#
 FactoryBot.define do
   factory :status_crowdsource do
     association :store

--- a/test/factories/stores.rb
+++ b/test/factories/stores.rb
@@ -24,6 +24,7 @@
 #  created_by_id    :bigint
 #  updated_by_id    :bigint
 #  from_osm         :boolean          default("false")
+#  original_id      :bigint
 #
 FactoryBot.define do
   factory :store do

--- a/test/models/store_test.rb
+++ b/test/models/store_test.rb
@@ -24,6 +24,7 @@
 #  created_by_id    :bigint
 #  updated_by_id    :bigint
 #  from_osm         :boolean          default("false")
+#  original_id      :bigint
 #
 require 'test_helper'
 


### PR DESCRIPTION
Added the statuses history logic.
When saving a crowdsource status, if there's none active, it becomes the active one.

TODO:
All of this should be async. Use active jobs to do it in the next version.