### PR TITLE
Reduce queries and serialization

### DIFF
--- a/app/models/status_crowdsource.rb
+++ b/app/models/status_crowdsource.rb
@@ -40,7 +40,8 @@ class StatusCrowdsource < Status
 
   def calculate_status
     votes = total_votes
-    return unless votes.any?
+    arr = votes.to_a
+    return if arr.empty?
 
     # We'll recalculate it for now
     # return if updated_time > votes.first.created_at

--- a/app/models/status_crowdsource.rb
+++ b/app/models/status_crowdsource.rb
@@ -40,8 +40,7 @@ class StatusCrowdsource < Status
 
   def calculate_status
     votes = total_votes
-    arr = votes.to_a
-    return if arr.empty?
+    return unless votes.any?
 
     # We'll recalculate it for now
     # return if updated_time > votes.first.created_at


### PR DESCRIPTION
Tried to reduce the calculation task to something a little quicker.

- only calculate when there have been new entries added for a given store;
- avoid extra queries for any? by serializing and checking if an array is empty or not;
- Includes objects on the query to avoid N+1 queries;