### PR TITLE
Calculate crowdsource status in a single query

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,7 @@ end
 group :test do
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '>= 2.15'
+  gem 'faker'
   gem 'selenium-webdriver'
   # Easy installation and use of web drivers to run system tests with browsers
   gem 'webdrivers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,6 +139,8 @@ GEM
     factory_bot_rails (5.1.1)
       factory_bot (~> 5.1.0)
       railties (>= 4.2.0)
+    faker (2.11.0)
+      i18n (>= 1.6, < 2)
     ffi (1.12.2)
     fugit (1.3.3)
       et-orbi (~> 1.1, >= 1.1.8)
@@ -402,6 +404,7 @@ DEPENDENCIES
   devise-i18n
   dotenv-rails
   factory_bot_rails
+  faker
   geocoder
   groupdate
   htmlentities

--- a/app/models/status_crowdsource.rb
+++ b/app/models/status_crowdsource.rb
@@ -21,78 +21,58 @@
 #
 class StatusCrowdsource < Status
   include TimeHelper
-  has_many :status_crowdsource_users
-
-  # TODO, this should be async! Move this to sidekiq+redis (or activejobs)
-  after_update :create_history
-
-  WEIGHT = {
-    first: 0.6,
-    second: 0.3,
-    third: 0.1
-  }.freeze
-
-  TIME_PARAMS = {
-    first: 11,
-    second: 22,
-    third: 33
-  }.freeze
 
   def calculate_status
-    votes = total_votes
-    return unless votes.any?
+    weight1 = 0.6
+    weight2 = 0.3
+    weight3 = 0.1
+    cutoff1 = 11
+    cutoff2 = 22
+    cutoff3 = 33
 
-    # We'll recalculate it for now
-    # return if updated_time > votes.first.created_at
+    self.class.connection.execute <<SQL
+    UPDATE statuses
+    SET status = t.status,
+      voters = t.voters,
+      updated_time = '#{DateTime.now}',
+      updated_at = '#{DateTime.now}'
+    FROM (
+      SELECT
+        statuses.id AS id,
+        ROUND((
+          SUM(status_crowdsource_users.status * CASE
+            WHEN status_crowdsource_users.created_at > NOW() - #{cutoff1} * INTERVAL '1 minute' THEN #{weight1}
+            WHEN status_crowdsource_users.created_at > NOW() - #{cutoff2} * INTERVAL '1 minute' THEN #{weight2}
+            ELSE #{weight3}
+            END
+          )
+        ) / (
+          SUM(CASE
+            WHEN status_crowdsource_users.created_at > NOW() - #{cutoff1} * INTERVAL '1 minute' THEN #{weight1}
+            WHEN status_crowdsource_users.created_at > NOW() - #{cutoff2} * INTERVAL '1 minute' THEN #{weight2}
+            ELSE #{weight3}
+            END
+          )
+        ), 2) AS status,
+        COUNT(1) AS voters
+      FROM statuses
+      JOIN status_crowdsource_users ON statuses.store_id = status_crowdsource_users.store_id
+      WHERE status_crowdsource_users.status IS NOT NULL
+      AND status_crowdsource_users.created_at > NOW() - #{cutoff3} * INTERVAL '1 minute'
+      GROUP BY statuses.id
+    ) AS t
+    WHERE t.id = statuses.id
+    AND statuses.type = 'StatusCrowdsource'
+    AND statuses.id = #{id}
+SQL
 
-    first_votes = []
-    second_votes = []
-    third_votes = []
-    first_time = (Time.now - TIME_PARAMS[:first].minutes).utc
-    second_time = (Time.now - TIME_PARAMS[:second].minutes).utc
+    reload
 
-    votes.each do |v|
-      case v.created_at
-      when first_time...DateTime::Infinity.new
-        first_votes << v
-      when second_time...first_time
-        second_votes << v
-      else
-        third_votes << v
-      end
-    end
-
-    # The formula is: (sum_a*weight_a + sum_b*weight_b + sum_c*weight_c)/(count_a*weight_a + ...)
-
-    first_voters = first_votes.count * WEIGHT[:first]
-    second_voters = second_votes.count * WEIGHT[:second]
-    third_voters = third_votes.count * WEIGHT[:third]
-    first_results = first_votes.pluck(:status).reduce(:+).to_f * WEIGHT[:first]
-    second_results = second_votes.pluck(:status).reduce(:+).to_f * WEIGHT[:second]
-    third_results = third_votes.pluck(:status).reduce(:+).to_f * WEIGHT[:third]
-
-    begin
-      new_status = (first_results + second_results + third_results) / (first_voters + second_voters + third_voters)
-    rescue StandardError
-      return
-    end
-
-    update(
-      status: new_status.round(2),
-      voters: total_votes.count,
-      updated_time: DateTime.now
-    )
+    # TODO, this should be async! Move this to sidekiq+redis (or activejobs)
+    create_history
   end
 
   private
-
-  def total_votes
-    StatusCrowdsourceUser
-      .where(store_id: store_id)
-      .where("created_at > '#{(Time.now - TIME_PARAMS[:third].minutes).utc.to_s(:db)}'")
-      .where.not(status: nil)
-      .order(created_at: :desc)
-  end
 
   # Saves the current status into history
   def create_history

--- a/app/models/status_crowdsource.rb
+++ b/app/models/status_crowdsource.rb
@@ -21,8 +21,70 @@
 #
 class StatusCrowdsource < Status
   include TimeHelper
+  has_many :status_crowdsource_users
+
+  # TODO, this should be async! Move this to sidekiq+redis (or activejobs)
+  after_update :create_history
+
+  WEIGHT = {
+    first: 0.6,
+    second: 0.3,
+    third: 0.1
+  }.freeze
+
+  TIME_PARAMS = {
+    first: 11,
+    second: 22,
+    third: 33
+  }.freeze
 
   def calculate_status
+    votes = total_votes
+    return unless votes.any?
+
+    # We'll recalculate it for now
+    # return if updated_time > votes.first.created_at
+
+    first_votes = []
+    second_votes = []
+    third_votes = []
+    first_time = (Time.now - TIME_PARAMS[:first].minutes).utc
+    second_time = (Time.now - TIME_PARAMS[:second].minutes).utc
+
+    votes.each do |v|
+      case v.created_at
+      when first_time...DateTime::Infinity.new
+        first_votes << v
+      when second_time...first_time
+        second_votes << v
+      else
+        third_votes << v
+      end
+    end
+
+    # The formula is: (sum_a*weight_a + sum_b*weight_b + sum_c*weight_c)/(count_a*weight_a + ...)
+
+    first_voters = first_votes.count * WEIGHT[:first]
+    second_voters = second_votes.count * WEIGHT[:second]
+    third_voters = third_votes.count * WEIGHT[:third]
+    first_results = first_votes.pluck(:status).reduce(:+).to_f * WEIGHT[:first]
+    second_results = second_votes.pluck(:status).reduce(:+).to_f * WEIGHT[:second]
+    third_results = third_votes.pluck(:status).reduce(:+).to_f * WEIGHT[:third]
+
+    begin
+      new_status = (first_results + second_results + third_results) / (first_voters + second_voters + third_voters)
+    rescue StandardError
+      return
+    end
+
+    update(
+      status: new_status.round(2),
+      voters: total_votes.count,
+      updated_time: DateTime.now
+    )
+  end
+
+  def calculate_status_new
     weight1 = 0.6
     weight2 = 0.3
     weight3 = 0.1
@@ -73,6 +135,14 @@ SQL
   end
 
   private
+
+  def total_votes
+    StatusCrowdsourceUser
+      .where(store_id: store_id)
+      .where("created_at > '#{(Time.now - TIME_PARAMS[:third].minutes).utc.to_s(:db)}'")
+      .where.not(status: nil)
+      .order(created_at: :desc)
+  end
 
   # Saves the current status into history
   def create_history

--- a/app/services/calculate_status.rb
+++ b/app/services/calculate_status.rb
@@ -1,16 +1,17 @@
 class CalculateStatus
   UPDATE_TIME = 1
 
-  def call
+  def call(new_cool: true)
     puts "[#{Time.now}] Going to calculate the statuses"
     duration = Benchmark.ms do
-      puts "[#{Time.now}] Calculating the Crowdsource status"
-      StatusCrowdsource
-        .joins(store: :status_crowdsource_users)
-        .where('status_crowdsource_users.created_at > ?', 2.hours.ago)
-        .find_each.with_index do |s, i|
+      puts "[#{Time.now}] Calculating the Crowdsource status #{new_cool ? 'new' : 'old'}"
+      StatusCrowdsource.find_each.with_index do |s, i|
         puts "Calculated #{i}" if (i % 100).zero?
-        s.calculate_status
+        if new_cool
+          s.calculate_status_new
+        else
+          s.calculate_status
+        end
       end
 
       puts "[#{Time.now}] Calculating the status"

--- a/spec/services/calculate_status_spec.rb
+++ b/spec/services/calculate_status_spec.rb
@@ -22,4 +22,35 @@ describe ImportStores do
       expect(store3.status_generals.first.status).to be_nil
     end
   end
+
+  context 'benchmark' do
+    before do
+      puts 'mass inserting...'
+      stores = create_list(:store, 10)
+      puts 'stores inserted'
+
+      data = Array.new(100_000) do |i|
+        time = Faker::Time.between(from: 2.hours.ago, to: 1.minute.ago)
+        {
+          store_id: stores[i % stores.size].id,
+          created_at: time,
+          updated_at: time,
+          status: 10
+        }
+      end
+
+      puts 'scu prepared'
+      StatusCrowdsourceUser.insert_all(data)
+
+      puts 'mass insert done'
+    end
+
+    it 'pulling rails' do
+      CalculateStatus.new.call(new_cool: false)
+    end
+
+    it 'single query' do
+      CalculateStatus.new.call(new_cool: true)
+    end
+  end
 end

--- a/spec/services/calculate_status_spec.rb
+++ b/spec/services/calculate_status_spec.rb
@@ -11,6 +11,8 @@ describe ImportStores do
       create(:status_crowdsource_user, status: 10, store: store1, created_at: a_time)
       create(:status_crowdsource_user, status: 10, store: store2, created_at: a_time - 30.minutes)
       create(:status_crowdsource_user, status: 10, store: store3, created_at: a_time - 3.hours)
+
+      sleep 1
       CalculateStatus.new.call
     end
 


### PR DESCRIPTION
This avoids pulling crowdsourced status to ruby.

The query is built in a way that we could change it to update every store status in a single query by just removing the `statuses.id = #{id}` part.

`updated_time` and `updated_at` are using `DateTime.now` instead of `NOW()` because the latter was causing tests to fail. This is probably related to the conditions in `services/calculate_status.rb`.
