### PR TITLE
Fix/deprecation warning

### DIFF
--- a/app/resources/api/v1/status_resource.rb
+++ b/app/resources/api/v1/status_resource.rb
@@ -20,7 +20,7 @@ module Api
 
       MAX_STORES = 300
 
-      attributes :id, :updated_time, :valid_until, :status,
+      attributes :updated_time, :valid_until, :status,
                  :queue, :store_id
 
       filter :store_id

--- a/config/initializers/jsonapi_resources.rb
+++ b/config/initializers/jsonapi_resources.rb
@@ -1,5 +1,5 @@
 JSONAPI.configure do |config|
-  config.exception_class_whitelist = [TooManyRequestsError]
+  config.exception_class_whitelist = ["TooManyRequestsError"]
   config.resource_cache = Rails.cache
   config.always_include_to_one_linkage_data = false
 end


### PR DESCRIPTION
- removes redundant :id on status resource;
- fixes deprecation warning by not including a constant but a string that will represent that constant on the initializer (thanks Wiki! =D)