### PR TITLE
Feature/beaches mgmt pages

### DIFF
--- a/app/controllers/beaches_controller.rb
+++ b/app/controllers/beaches_controller.rb
@@ -1,0 +1,7 @@
+class BeachesController < StoresController
+  private
+
+  def set_stores
+    @stores = Store.where(store_type: :beach)
+  end
+end

--- a/app/controllers/map_controller.rb
+++ b/app/controllers/map_controller.rb
@@ -20,6 +20,8 @@ class MapController < ApplicationController
       @shops = @shops.where(id: current_user.user_stores.where(approved: true).pluck(:store_id))
     end
 
+    @shops = @shops.where(store_type: :beach) if current_user.beach_admin?
+
     @shops = @shops.index_by(&:id)
 
     respond_to do |format|

--- a/app/controllers/stores_controller.rb
+++ b/app/controllers/stores_controller.rb
@@ -82,7 +82,7 @@ class StoresController < ApplicationController
   def destroy
     @store.destroy
     respond_to do |format|
-      format.html { redirect_to stores_url(search_params), notice: 'Store was successfully destroyed.' }
+      format.html { redirect_to polymorphic_url(controller_name, search_params), notice: 'Store was successfully destroyed.' }
       format.json { head :no_content }
     end
   end

--- a/app/controllers/stores_controller.rb
+++ b/app/controllers/stores_controller.rb
@@ -82,7 +82,10 @@ class StoresController < ApplicationController
   def destroy
     @store.destroy
     respond_to do |format|
-      format.html { redirect_to polymorphic_url(controller_name, search_params), notice: 'Store was successfully destroyed.' }
+      format.html do
+        redirect_to polymorphic_url(controller_name, search_params),
+                    notice: 'Store was successfully destroyed.'
+      end
       format.json { head :no_content }
     end
   end
@@ -97,7 +100,10 @@ class StoresController < ApplicationController
     @stores.update_all(state: :live) # rubocop:disable Rails/SkipsModelValidations
 
     respond_to do |format|
-      format.html { redirect_to polymorphic_url(controller_name), notice: t('controllers.stores.approve_all.notice', size: size) }
+      format.html do
+        redirect_to polymorphic_url(controller_name),
+                    notice: t('controllers.stores.approve_all.notice', size: size)
+      end
       format.json { head :no_content }
     end
   end

--- a/app/controllers/stores_controller.rb
+++ b/app/controllers/stores_controller.rb
@@ -1,11 +1,12 @@
 class StoresController < ApplicationController
-  load_and_authorize_resource except: [:statuses]
+  load_and_authorize_resource :store, except: [:statuses, :index, :approve_all]
+  before_action :set_stores, only: [:index, :approve_all]
   skip_before_action :authenticate_user!, if: proc { request.format.json? && action_name == 'index' }
 
   # GET /stores
   # GET /stores.json
   def index
-    @stores = Store.search(params[:search])
+    @stores = @stores.search(params[:search])
     @stores = @stores.by_country(params[:country]) if params[:country].present?
     @stores = @stores.by_group(params[:group]) if params[:group].present?
 
@@ -87,7 +88,7 @@ class StoresController < ApplicationController
   end
 
   def approve_all
-    @stores = Store.search(params[:search])
+    @stores = @stores.search(params[:search])
     @stores = @stores.by_group(params[:group]) if params[:group].present?
     @stores = @stores.by_country(params[:country]) if params[:country].present?
     @stores = @stores.by_state(params[:state]) if params[:state].present?
@@ -96,7 +97,7 @@ class StoresController < ApplicationController
     @stores.update_all(state: :live) # rubocop:disable Rails/SkipsModelValidations
 
     respond_to do |format|
-      format.html { redirect_to stores_url, notice: t('controllers.stores.approve_all.notice', size: size) }
+      format.html { redirect_to polymorphic_url(controller_name), notice: t('controllers.stores.approve_all.notice', size: size) }
       format.json { head :no_content }
     end
   end
@@ -112,6 +113,10 @@ class StoresController < ApplicationController
   end
 
   private
+
+  def set_stores
+    @stores = Store.where.not(store_type: :beach)
+  end
 
   # Only allow a list of trusted parameters through.
   def store_params

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -14,6 +14,9 @@ class Ability
     if user.admin?
       can :manage, :all
 
+    elsif user.beach_admin?
+      can :manage, :beaches
+
     elsif user.general_manager?
       can [:new, :create, :edit, :update], Store
       can [:new, :create], User

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,7 +37,8 @@ class User < ApplicationRecord
 
   has_secure_token :store_owner_code
 
-  enum role: {user: 0, store_owner: 1, general_manager: 2, admin: 3, contributor: 4}
+  enum role: {user: 0, store_owner: 1, general_manager: 2, admin: 3, contributor: 4,
+    beach_admin: 5, beach_manager: 6}
 
   def self.search(search)
     return all unless search
@@ -57,6 +58,10 @@ class User < ApplicationRecord
 
     ApiKey.where(user_id: id).update(active: false)
     ApiKey.create(user: self, active: true)
+  end
+
+  def any_admin?
+    admin? || beach_admin?
   end
 
   protected

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,7 +38,7 @@ class User < ApplicationRecord
   has_secure_token :store_owner_code
 
   enum role: {user: 0, store_owner: 1, general_manager: 2, admin: 3, contributor: 4,
-    beach_admin: 5, beach_manager: 6}
+              beach_admin: 5, beach_manager: 6}
 
   def self.search(search)
     return all unless search

--- a/app/views/beaches/_form.html.erb
+++ b/app/views/beaches/_form.html.erb
@@ -1,0 +1,182 @@
+<div class="row mt-4">
+  <div class="col-md-12">
+    <div class="alert alert-warning">
+      <%= t('views.stores.form.info_deleting') %>
+    </div>
+    <%= form_with(model: store, local: true) do |form| %>
+      <% if store.errors.any? %>
+        <div id="error_explanation">
+          <h2><%= pluralize(store.errors.count, "error") %> impediram store de ser guardado:</h2>
+
+          <ul>
+            <% store.errors.full_messages.each do |message| %>
+              <li><%= message %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+
+      <div class="form-row">
+        <div class="form-group col-md-6">
+          <%= form.label :state, class: "col-sm-4 col-form-label" %>
+          <% if can? :manage_state, Store %>
+            <%= form.select :state, enum_options_for_select(Store, :state), {}, class: "form-control" %>
+          <% else %>
+            <span class="form-control"><%= enum_l(form.object, :state) %></span>
+          <% end %>
+          <small class="form-text text-muted">
+            <%= t('views.stores.form.help_state_html') %>
+          </small>
+        </div>
+
+        <div class="form-group col-md-6">
+          <%= form.label :open, class: "col-sm-4 col-form-label" %>
+          <div class="col-sm-10">
+            <%= form.check_box :open, class: 'form-control' %>
+          </div>
+          <small class="form-text text-muted">
+            <%= t('views.stores.form.help_open') %>
+          </small>
+        </div>
+      </div>
+
+      <div class="form-row">
+        <div class="form-group col-md-6">
+          <%= form.label :name, class: "col-sm-4 col-form-label" %>
+          <%= form.text_field :name, class: "form-control" %>
+        </div>
+
+        <div class="form-group col-md-6">
+          <%= form.label :store_type, class: "col-sm-8 col-form-label" %>
+          <%= form.select :store_type, enum_options_for_select(Store, :store_type), {}, class: 'form-control' %>
+        </div>
+      </div>
+
+      <div class="form-row<%= " hidden" unless @store.beach? %>">
+        <div class="form-group col-md-6">
+          <%= form.label :category, class: "col-sm-4 col-form-label" %>
+          <%= form.select :category, enum_options_for_select(Store, :category, true), {}, class: 'form-control',
+                          class: "form-control" %>
+        </div>
+
+        <div class="form-group col-md-6">
+          <%= form.label :quality_flag, class: "col-sm-4 col-form-label" %>
+          <%= form.check_box :quality_flag,  class: "form-control" %>
+        </div>
+      </div>
+
+      <div class="form-row">
+        <div class="form-group col-md-9">
+          <%= form.label :group, class: "col-sm-4 col-form-label" %>
+          <%= form.text_field :group, class: "form-control" %>
+          <small class="form-text text-muted">
+            <%= t('views.stores.form.help_group') %>
+          </small>
+        </div>
+
+        <div class="form-group col-md-3">
+          <%= form.label :capacity, class: "col-sm-4 col-form-label" %>
+          <%= form.number_field :capacity, class: "form-control" %>
+        </div>
+      </div>
+
+      <div class="form-row">
+        <div class="form-group col-md-8">
+          <%= form.label :street, class: "col-sm-4 col-form-label" %>
+          <%= form.text_field :street, class: "form-control" %>
+        </div>
+
+        <div class="form-group col-md-4">
+          <%= form.label :zip_code, class: "col-sm-8 col-form-label" %>
+          <%= form.text_field :zip_code, class: "form-control" %>
+        </div>
+      </div>
+
+      <div class="form-row">
+        <div class="form-group col-md-4">
+          <%= form.label :city, class: "col-sm-4 col-form-label" %>
+          <%= form.text_field :city, class: "form-control" %>
+        </div>
+
+        <div class="form-group col-md-4">
+          <%= form.label :district, class: "col-sm-4 col-form-label" %>
+          <%= form.text_field :district, class: "form-control" %>
+        </div>
+
+        <div class="form-group col-md-4">
+          <%= form.label :country, class: "col-sm-4 col-form-label" %>
+          <%= form.text_field :country, class: "form-control" %>
+          <small class="form-text text-muted">
+            <%= t('views.stores.form.help_country') %>
+          </small>
+        </div>
+      </div>
+
+      <div class="form-row">
+        <div class="form-group col-md-6">
+          <%= form.label :latitude, class: "col-sm-4 col-form-label" %>
+          <%= form.text_field :latitude, class: "form-control" %>
+          <small class="form-text text-muted">
+            <%= t('views.stores.form.help_coordinates') %>
+          </small>
+        </div>
+
+        <div class="form-group col-md-6">
+          <%= form.label :longitude, class: "col-sm-4 col-form-label" %>
+          <%= form.text_field :longitude, class: "form-control" %>
+          <small class="form-text text-muted">
+            <%= t('views.stores.form.help_coordinates') %>
+          </small>
+        </div>
+      </div>
+
+      <div class="form-group">
+        <%= form.label :details, class: "col-sm-4 col-form-label" %>
+        <%= form.text_area :details, class: "form-control" %>
+      </div>
+
+      <% if current_user.admin? || current_user.general_manager? %>
+        <div class="form-group">
+          <%= form.label :manager_ids, value: t('activerecord.enums.user.roles.store_owner'), class: "col-sm-4 col-form-label" %>
+          <%= form.select :manager_ids, @store.managers&.collect{|s| [s.text, s.id]}, {},
+            {class: "form-control store-owners-select", multiple: true} %>
+        </div>
+      <% end %>
+
+      <% if current_user.admin? || current_user.store_owner? %>
+        <div class="form-group nested-form-fields">
+          <fieldset>
+            <legend><%= t('views.stores.form.phone_number') %></legend>
+            <%= form.fields_for :phones do |phone_form| %>
+              <%= render 'phone_fields', f: phone_form %>
+            <% end %>
+            <%= link_to_add_fields t('views.stores.form.add_phone'), form, :phones %>
+          </fieldset>
+        </div>
+
+        <% if @store.week_days.any? %>
+          <div class="form-group nested-form-fields">
+            <fieldset>
+              <legend><%= t('views.stores.form.phone_call_interval') %></legend>
+            <div class="form-group col-md-2 my-1">
+              <%= form.number_field :phone_call_interval, placeholder: 'Interval', class: 'form-control', min: 30, max: 179 %>
+            </div>
+            </fieldset>
+          </div>
+          <div class="form-group nested-form-fields">
+            <fieldset>
+              <legend><%= t('views.stores.form.schedule') %></legend>
+              <%= form.fields_for :week_days, @store.week_days.order(:day) do |week_days_form| %>
+                <%= render 'week_day_fields', f: week_days_form %>
+              <% end %>
+            </fieldset>
+          </div>
+        <% end %>
+      <% end %>
+
+      <div class="form-group">
+        <%= form.submit t('views.form.submit'), class: "btn btn-primary" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/beaches/_phone_fields.html.erb
+++ b/app/views/beaches/_phone_fields.html.erb
@@ -1,0 +1,22 @@
+<div class="nested-fields">
+  <%= f.hidden_field :_destroy %>
+  <div class="form-row">
+    <div class="form-group col-md-4 my-1">
+      <%= f.label :phone_number, class: 'sr-only' %>
+      <%= f.phone_field :phone_number, placeholder: 'Number', class: 'form-control' %>
+    </div>
+    <div class="form-group col-md-4 my-1">
+      <%= f.label :name, class: 'sr-only' %>
+      <%= f.text_field :name, placeholder: 'Name', class: 'form-control' %>
+    </div>
+    <div class="col-auto my-1">
+      <div class="form-check">
+        <%= f.check_box :active %>
+        <%= f.label :active %>
+      </div>
+    </div>
+    <div class="col-auto my-1">
+      <%= link_to "Remove", '#', class: "remove_fields btn btn-danger" %>
+    </div>
+  </div>
+</div>

--- a/app/views/beaches/_store.json.jbuilder
+++ b/app/views/beaches/_store.json.jbuilder
@@ -1,0 +1,1 @@
+json.extract! store, :id, :text

--- a/app/views/beaches/_table.html.erb
+++ b/app/views/beaches/_table.html.erb
@@ -34,7 +34,7 @@
           <td><%= store.longitude&.round(3) %></td>
           <td>
             <%= link_to t('views.actions.show'), store %>
-            <% if can? :edit, store %>
+            <% if can? :edit, :beaches %>
               |
               <%= link_to t('views.actions.edit'), edit_store_path(store) %>
             <% end %>
@@ -42,10 +42,10 @@
               |
               <%= link_to t('views.stores.show.statuses'), statuses_store_path(store) %>
             <% end %>
-            <% if can? :destroy, store %>
+            <% if can? :destroy, :beaches %>
               |
               <%= link_to t('views.actions.destroy'),
-                store_path(store, state: params[:state], group: params[:group],
+                beach_path(store, state: params[:state], group: params[:group],
                                  search: params[:search], country: params[:country],
                                  store_type: params[:store_type]), method: :delete,
                                  data: { confirm: t('views.actions.confirm_destroy') } %>

--- a/app/views/beaches/_table.html.erb
+++ b/app/views/beaches/_table.html.erb
@@ -1,0 +1,59 @@
+<%= page_entries_info stores, entry_name: t('views.beaches.index.entry_name') %>
+<div class="table-responsive">
+  <table class="table table-sm">
+    <thead>
+      <tr>
+        <th><%= Store.human_attribute_name(:name) %></th>
+        <th><%= Store.human_attribute_name(:state) %></th>
+        <th><%= Store.human_attribute_name(:street) %></th>
+        <% if current_user.any_admin? || current_user.general_manager? %>
+          <th>Created by</th>
+          <th>Updated by</th>
+        <% end %>
+        <th><%= Store.human_attribute_name(:latitude) %></th>
+        <th><%= Store.human_attribute_name(:longitude) %></th>
+        <th><%= t('views.actions.title') %></th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% stores.each do |store| %>
+        <tr>
+          <td><%= link_to store.name, store %></td>
+          <td><%= enum_l(store, :state) %></td>
+          <td><%= store.address %></td>
+          <% if current_user.any_admin? || current_user.general_manager? %>
+            <td>
+              <%= link_to(store.created_by.display_name, store.created_by) if store.created_by %>
+            </td>
+            <td>
+              <%= link_to(store.updated_by.display_name, store.updated_by) if store.updated_by %>
+            </td>
+          <% end %>
+          <td><%= store.latitude&.round(3) %></td>
+          <td><%= store.longitude&.round(3) %></td>
+          <td>
+            <%= link_to t('views.actions.show'), store %>
+            <% if can? :edit, store %>
+              |
+              <%= link_to t('views.actions.edit'), edit_store_path(store) %>
+            <% end %>
+            <% if can? :read, :statuses_store %>
+              |
+              <%= link_to t('views.stores.show.statuses'), statuses_store_path(store) %>
+            <% end %>
+            <% if can? :destroy, store %>
+              |
+              <%= link_to t('views.actions.destroy'),
+                store_path(store, state: params[:state], group: params[:group],
+                                 search: params[:search], country: params[:country],
+                                 store_type: params[:store_type]), method: :delete,
+                                 data: { confirm: t('views.actions.confirm_destroy') } %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+  <%= paginate stores %>
+</div>

--- a/app/views/beaches/_week_day_fields.html.erb
+++ b/app/views/beaches/_week_day_fields.html.erb
@@ -1,0 +1,22 @@
+<div class="nested-fields">
+  <div class="form-row">
+    <div class="form-group col-md-2 my-1">
+      <%= f.label :day, class: 'sr-only' %>
+      <%= f.phone_field :day, class: 'form-control', disabled: true %>
+    </div>
+    <div class="form-group col-md-4 my-1">
+      <%= f.label :opening_hour %>
+      <%= f.time_select :opening_hour, placeholder: 'Opening hour', class: 'form-control' %>
+    </div>
+    <div class="form-group col-md-4 my-1">
+      <%= f.label :closing_hour %>
+      <%= f.time_select :closing_hour, placeholder: 'Closing hour', class: 'form-control' %>
+    </div>
+    <div class="col-auto my-1">
+      <div class="form-check">
+        <%= f.check_box :active %>
+        <%= f.label :active %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/beaches/edit.html.erb
+++ b/app/views/beaches/edit.html.erb
@@ -1,0 +1,13 @@
+<% content_for :page_title, t('views.edit.title', resource: Store.model_name.human) %>
+
+<div class="row mt-3">
+  <div class="col-md-11">
+    <h1><%= "#{t('views.actions.edit')} #{Store.model_name.human(count: 1)}" %></h1>
+  </div>
+  <div class="col-md-1">
+    <%= link_to t('views.actions.show'), @store,
+      class: 'btn btn-sm btn-outline-primary' %>
+</div>
+</div>
+
+<%= render 'form', store: @store %>

--- a/app/views/beaches/index.html.erb
+++ b/app/views/beaches/index.html.erb
@@ -1,0 +1,50 @@
+<% content_for :page_title, t('views.beaches.index.title') %>
+
+<div class="row mt-3">
+  <div class="col-md-<%= current_user.any_admin? && params[:state] == 'waiting_approval' ? 10 : 11 %>">
+    <h1><%= t('views.beaches.index.title') %></h1>
+  </div>
+  <div class="col-md-<%= current_user.any_admin? && params[:state] == 'waiting_approval' ? 2 : 1 %>">
+    <% if current_user.any_admin? && params[:state] == 'waiting_approval' %>
+      <%= link_to t('views.actions.approve_all'), approve_all_beaches_path(group: params[:group], search: params[:search], store_type: params[:store_type], state: params[:state]), method: :post,
+        data: {confirm: t('views.stores.index.confirm_approval')},
+        class: 'btn btn-sm btn-outline-success' %>
+    <% end %>
+    <% if can? :new, Store %>
+      <%= link_to t('views.actions.new'), new_beach_path,
+        class: 'btn btn-sm btn-outline-primary' %>
+    <% end %>
+    <% if current_user.any_admin? %>
+      <%= link_to t('views.actions.download'),
+                  beaches_path(group: params[:group], search: params[:search],
+                    store_type: params[:store_type], state: params[:state],
+                    format: 'csv'),
+                  class: 'btn btn-sm btn-outline-success' %>
+    <% end %>
+  </div>
+</div>
+
+<div class="row mt-2">
+  <div class="col-md-12">
+    <%= form_tag beaches_path, method: :get, class: 'form-inline' do %>
+      <%= label_tag :search, 'Search', class: 'sr-only' %>
+      <%= text_field_tag :search, params[:search], class: 'form-control col-md-7 mb-2 mr-sm-2',
+        placeholder: t('views.stores.search.placeholder') %>
+      <%= label_tag :state, 'State', class: 'sr-only' %>
+      <%= select_tag :state, options_for_select(enum_options_for_select(Store, :state), params[:state]), {include_blank: t('views.stores.search.filter_state'),
+                                                                                                          class: 'form-control col-md-3 mb-2 mr-sm-2'} %>
+      <%= submit_tag t('views.stores.search.button'),
+        class: 'btn btn-primary mb-2' %>
+    <% end %>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-12">
+    <div class="main-card mb-3 card">
+      <div class="card-body">
+        <%= render 'table', stores: @stores %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/beaches/index.json.jbuilder
+++ b/app/views/beaches/index.json.jbuilder
@@ -1,0 +1,3 @@
+json.results do
+  json.array! @stores, partial: 'stores/store', as: :store
+end

--- a/app/views/beaches/new.html.erb
+++ b/app/views/beaches/new.html.erb
@@ -1,0 +1,15 @@
+<% content_for :page_title, t('views.actions.new', resource: Store.model_name.human) %>
+
+<div class="row mt-3">
+  <div class="col-md-11">
+    <h1><%= "#{t('views.actions.new')} #{Store.model_name.human(count: 1)}" %></h1>
+  </div>
+  <% if can? :new, Store %>
+    <div class="col-md-1">
+      <%= link_to t('views.actions.back'), stores_path,
+        class: 'btn btn-sm btn-outline-primary' %>
+  </div>
+<% end %>
+</div>
+
+<%= render 'form', store: @store %>

--- a/app/views/beaches/show.html.erb
+++ b/app/views/beaches/show.html.erb
@@ -1,0 +1,114 @@
+<% content_for :page_title, @store.name&.titleize %>
+
+<div class="row mt-3">
+  <div class="col-md-10">
+    <span class="h2"><%= @store.name %></span>
+    <%= badge_for @store %>
+  </div>
+  <div class="col-md-2">
+    <% if can? :edit, @store %>
+      <%= link_to t('views.actions.edit'), edit_store_path(@store),
+        class: 'btn btn-sm btn-outline-primary' %>
+    <% end %>
+    <% if can? :read, :statuses_store %>
+      <%= link_to t('views.stores.show.statuses'), statuses_store_path(@store),
+        class: 'btn btn-sm btn-outline-info' %>
+    <% end %>
+  </div>
+</div>
+
+<div class="row mt-4">
+  <div class="col-md-6">
+    <div class="card">
+      <div class="card-body">
+        <p>
+          <strong><%= Store.human_attribute_name(:name) %>:</strong>
+          <%= @store.name %>
+        </p>
+        <p>
+          <strong><%= Store.human_attribute_name(:group) %>:</strong>
+          <%= link_to @store.group, stores_path(group: @store.group) %>
+        </p>
+        <p>
+          <strong><%= Store.human_attribute_name(:store_type) %>:</strong>
+          <%= link_to enum_l(@store, :store_type), stores_path(store_type: @store.store_type) %>
+        </p>
+        <% if current_user&.admin? %>
+          <p>
+            <strong><%= Store.human_attribute_name(:open) %>:</strong>
+            <%= @store.open %>
+          </p>
+          <p>
+          <strong><%= Store.human_attribute_name(:created_by) %>:</strong>
+            <%= link_to(@store.created_by.display_name, @store.created_by) if @store.created_by %>
+          </p>
+          <p>
+            <strong><%= Store.human_attribute_name(:updated_by) %>:</strong>
+            <%= link_to(@store.updated_by.display_name, @store.updated_by) if @store.updated_by %>
+          </p>
+        <% end %>
+        <% if current_user&.admin? || (current_user.store_owner? && current_user.stores.include?(@store)) %>
+          <p><strong><%= Store.human_attribute_name(:phones) %>:</strong><br>
+            <ul>
+              <% @store.phones.each do |p| %>
+                <li><%= "#{p.phone_number} (#{p.name})" %> <%= p.active? ? 'Active' : 'Not active' %></li>
+              <% end %>
+            </ul>
+          </p>
+          <p><strong><%= t('activerecord.enums.user.roles.store_owner') %></strong><br>
+            <ul>
+              <% @store.managers.each do |user| %>
+                <li>
+                  <% if current_user.admin? %>
+                    <%= link_to user.display_name, user %>
+                  <% else %>
+                    <%= user.display_name %>
+                  <% end %>
+                </li>
+              <% end %>
+            </ul>
+          </p>
+        <% end %>
+      </div>
+    </div>
+  </div>
+
+  <div class="col-md-6">
+    <div class="card">
+      <div class="card-body">
+        <p>
+          <strong><%= Store.human_attribute_name(:street) %>:</strong>
+          <%= @store.street %>
+        </p>
+        <p>
+          <strong><%= Store.human_attribute_name(:zip_code) %>:</strong>
+          <%= @store.zip_code %>
+        </p>
+        <p>
+          <strong><%= Store.human_attribute_name(:city) %>:</strong>
+          <%= @store.city %>
+        </p>
+        <p>
+          <strong><%= Store.human_attribute_name(:district) %>:</strong>
+          <%= @store.district %>
+        </p>
+        <p>
+          <strong><%= Store.human_attribute_name(:country) %>:</strong>
+          <%= @store.country %>
+        </p>
+        <p>
+          <strong><%= t('views.stores.index.coordinates') %>:</strong>
+          <%= [@store.latitude, @store.longitude].compact.join(', ') %>
+        </p>
+        <p>
+          <strong><%= Store.human_attribute_name(:capacity) %>:</strong>
+          <%= @store.capacity %>
+        </p>
+        <p>
+          <strong><%= Store.human_attribute_name(:details) %>:</strong>
+          <%= @store.details %>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/beaches/show.json.jbuilder
+++ b/app/views/beaches/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'stores/store', store: @store

--- a/app/views/beaches/statuses.html.erb
+++ b/app/views/beaches/statuses.html.erb
@@ -1,0 +1,77 @@
+<% content_for :page_title, t('views.stores.statuses.title', store: @store.name&.titleize) %>
+
+<div class="row mt-3">
+  <div class="col-md-11">
+    <span class="h2"><%= @store.name %></span>
+    <%= badge_for @store %>
+  </div>
+  <% if can? :edit, @store %>
+    <div class="col-md-1">
+      <%= link_to t('views.actions.back'), @store, class: 'btn btn-sm btn-outline-primary' %>
+    </div>
+  <% end %>
+</div>
+
+<div class="row">
+  <div class="col-md-12">
+    <div class="main-card mb-3 card">
+      <div class="card-body">
+        <h5 class="card-title"><%= Status.model_name.human(count: 1) %></h5>
+        <div class="table-responsive">
+          <table class="table table-sm">
+            <thead>
+              <tr>
+                <th><%= Status.human_attribute_name(:type) %></th>
+                <th><%= Status.human_attribute_name(:updated_time) %></th>
+                <th><%= Status.human_attribute_name(:status) %></th>
+                <th><%= Status.human_attribute_name(:voters) %></th>
+                <th><%= Status.human_attribute_name(:previous_status) %></th>
+                <th><%= Status.human_attribute_name(:previous_voters) %></th>
+                <th><%= Status.human_attribute_name(:is_official) %></th>
+                <th><%= Status.human_attribute_name(:active) %></th>
+              </tr>
+            </thead>
+
+            <tbody>
+              <% @statuses.each do |status| %>
+                <tr <%= 'class=table-success' if status.is_a?(StatusGeneral) %>>
+                  <td><%= status.type %></td>
+                  <td><%= status.updated_time&.strftime('%H:%M %d/%m/%Y') %></td>
+                  <td><%= status.status&.round(3) %></td>
+                  <td><%= status.voters %></td>
+                  <td><%= status.previous_status&.round(3) %></td>
+                  <td><%= status.previous_voters %></td>
+                  <td><%= status.is_official %></td>
+                  <td><%= status.active %></td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<% if current_user.admin? %>
+  <div class="row">
+    <div class="col-md-12">
+      <div class="main-card mb-3 card">
+        <div class="card-body">
+          <h5 class="card-title"><%= t('views.status_crowdsource_users.index.title') %></h5>
+          <%= render 'status_crowdsource_users/table', status_crowdsource_users: @status_crowdsource_users %>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      <div class="main-card mb-3 card">
+        <div class="card-body">
+          <h5 class="card-title"><%= t('views.status_estimations.index.title') %></h5>
+          <%= render 'status_estimations/table', histories: @estimation_histories %>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -39,6 +39,16 @@
               <% end %>
             </div>
         <% end %>
+        <% if can? :read, :beaches %>
+          <li class="nav-item <%= 'active' if controller_name == 'beaches' %>">
+            <%= link_to beaches_path, class: 'nav-link' do %>
+              <%= t('views.beaches.index.title') %>
+              <% if controller_name == 'beaches' %>
+                <span class="sr-only">(<%= t('views.shared.navbar.current') %>)</span>
+              <% end %>
+            <% end %>
+          </li>
+        <% end %>
         <% if can? :read, StatusCrowdsourceUser %>
           <li class="nav-item <%= 'active' if controller_name == 'status_crowdsource_users' %>">
             <%= link_to status_crowdsource_users_path, class: 'nav-link' do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,6 +72,8 @@ en:
           general_manager: 'General manager'
           admin: 'Administrator'
           contributor: 'Contributor'
+          beach_admin: 'Administrator - Beaches'
+          beach_manager: 'Beach Manager'
       store:
         states:
           waiting_approval: 'Waiting approval'
@@ -203,6 +205,10 @@ en:
         add_phone: "Add Phone"
         schedule: "Schedule"
         phone_call_interval: "Phone Call Interval (minutes)"
+    beaches:
+      index:
+        title: 'Beaches'
+        entry_name: 'beach'
     status_crowdsource_users:
       index:
         title: 'Reported statuses'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -75,6 +75,8 @@ es:
           general_manager: 'Gerente de grupo'
           admin: 'Administrador'
           contributor: 'Voluntario/a'
+          beach_admin: 'Administrador - Playas'
+          beach_manager: 'Gerente Playa'
       store:
         states:
           waiting_approval: 'Esperando a ser validado'
@@ -212,6 +214,10 @@ es:
         add_phone: "Añadir Teléfono"
         schedule: "Horario"
         phone_call_interval: "Intervalo de llamada telefónica (minutos)"
+    beaches:
+      index:
+        title: 'Playas'
+        entry_name: 'playa'
     status_crowdsource_users:
       index:
         title: 'Estados reportados'

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -72,6 +72,8 @@ pt:
           general_manager: 'Gestor do sistema'
           admin: 'Administrador'
           contributor: 'Voluntário/a'
+          beach_admin: 'Adminstrador - Praias'
+          beach_manager: 'Concessionário Praias'
       store:
         states:
           waiting_approval: 'Aguarda validação'
@@ -209,6 +211,10 @@ pt:
         add_phone: "Adicionar Telefone"
         schedule: "Horário"
         phone_call_interval: "Intervalo entre chamadas telefónicas (minutos)"
+    beaches:
+      index:
+        title: 'Praias'
+        entry_name: 'praia'
     status_crowdsource_users:
       index:
         title: 'Estados reportados'

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -54,6 +54,8 @@ sk:
           general_manager: 'Hlavný manažér'
           admin: 'Administrátor'
           contributor: 'Prispievateľ'
+          beach_admin:
+          beach_manager:
       store:
         states:
           waiting_approval: 'Očakáva sa schválenie'
@@ -172,6 +174,10 @@ sk:
         add_phone: "Pridať tel. číslo"
         schedule: "Otváracie hodiny"
         phone_call_interval: "Interval pre telefónny hovor (minúty)"
+    beaches:
+      index:
+        title: 'Praias'
+        entry_name: 'praia'
     devise:
       registrations:
         new:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,9 @@ Rails.application.routes.draw do
       get :statuses, on: :member
       resources :status_store_owners, only: [:new, :create]
     end
+    resources :beaches do
+      post :approve_all, on: :collection
+    end
     resources :status_crowdsource_users, only: [:index]
     resources :manage_stores, only: [:index]
     resources :user_stores, only: [:index, :update]


### PR DESCRIPTION
I've started adding the views to manage the beaches on the admin side of the tool, this is still work in progress, but will use the PR to keep track of things:

- [x] add new roles [beach_admin, beach_manager]
- [ ] finalise authorization rules for the new roles;
- [x] adds index view for beaches;
- [x] adds approval flow for beaches;
- [ ] update beaches show page to show all the beach configuration details;
- [ ] update beaches edit page to enable editing all the different fields;
- [ ] copy beach_manager admin pages from store_owner pages;