### PR TITLE
Removes DECO only attributes, and their references

### DIFF
--- a/app/controllers/beaches_controller.rb
+++ b/app/controllers/beaches_controller.rb
@@ -63,11 +63,10 @@ class BeachesController < StoresController
                         :district, :store_type, :latitude, :longitude,
                         :municipality, :store_type, :open, :capacity, :details,
                         beach_configuration_attributes: [
-                          :id, :category, :quality_flag, :beach_type,
-                          :ground, :restrictions, :risk_areas, :average_users,
+                          :id, :quality_flag,
                           :guarded, :first_aid_station, :wc, :showers,
                           :accessibility, :garbage_collection, :cleaning,
-                          :info_panel, :restaurant, :parking, :parking_spots,
+                          :info_panel, :parking,
                           :season_start, :season_end, :beach_support,
                           :water_chair, :construction, :collapsing_risk,
                           :bathing_support, :water_classification, :sapo_code

--- a/app/models/beach_configuration.rb
+++ b/app/models/beach_configuration.rb
@@ -3,12 +3,6 @@
 # Table name: beach_configurations
 #
 #  id                       :bigint           not null, primary key
-#  category                 :integer
-#  beach_type               :string
-#  ground                   :string
-#  restrictions             :string
-#  risk_areas               :string
-#  average_users            :integer
 #  guarded                  :boolean
 #  first_aid_station        :boolean
 #  wc                       :boolean
@@ -17,26 +11,12 @@
 #  garbage_collection       :boolean
 #  cleaning                 :boolean
 #  info_panel               :boolean
-#  restaurant               :boolean
 #  parking                  :boolean
-#  parking_spots            :integer
 #  season_start             :date
 #  season_end               :date
 #  water_quality            :integer
 #  water_quality_url        :string
 #  quality_flag             :boolean
-#  water_quality_entity     :string
-#  water_quality_contact    :string
-#  water_contact_email      :string
-#  security_entity          :string
-#  security_entity_contact  :string
-#  security_entity_email    :string
-#  health_authority         :string
-#  health_authority_contact :string
-#  health_authority_email   :string
-#  municipality             :string
-#  municipality_contact     :string
-#  municipality_email       :string
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null
 #  store_id                 :bigint
@@ -53,8 +33,5 @@
 #
 class BeachConfiguration < ApplicationRecord
   belongs_to :store
-
-  enum category: {ocean: 1, river: 2}
-
   scope :by_state, ->(state) { where(state: state) }
 end

--- a/app/serializers/beach_configuration_serializer.rb
+++ b/app/serializers/beach_configuration_serializer.rb
@@ -3,12 +3,6 @@
 # Table name: beach_configurations
 #
 #  id                       :bigint           not null, primary key
-#  category                 :integer
-#  beach_type               :string
-#  ground                   :string
-#  restrictions             :string
-#  risk_areas               :string
-#  average_users            :integer
 #  guarded                  :boolean
 #  first_aid_station        :boolean
 #  wc                       :boolean
@@ -17,26 +11,12 @@
 #  garbage_collection       :boolean
 #  cleaning                 :boolean
 #  info_panel               :boolean
-#  restaurant               :boolean
 #  parking                  :boolean
-#  parking_spots            :integer
 #  season_start             :date
 #  season_end               :date
 #  water_quality            :integer
 #  water_quality_url        :string
 #  quality_flag             :boolean
-#  water_quality_entity     :string
-#  water_quality_contact    :string
-#  water_contact_email      :string
-#  security_entity          :string
-#  security_entity_contact  :string
-#  security_entity_email    :string
-#  health_authority         :string
-#  health_authority_contact :string
-#  health_authority_email   :string
-#  municipality             :string
-#  municipality_contact     :string
-#  municipality_email       :string
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null
 #  store_id                 :bigint
@@ -55,40 +35,21 @@ class BeachConfigurationSerializer
   include FastJsonapi::ObjectSerializer
   belongs_to :store
 
-  attributes :category,
-             :beach_type,
-             :average_users,
-             :guarded,
+  attributes :guarded,
              :first_aid_station,
              :wc,
              :showers,
              :accessibility,
              :parking,
-             :parking_spots,
              :season_start,
              :season_end,
              :water_quality,
              :water_quality_url,
              :quality_flag
-  #             :restaurant,
   #             :garbage_collection,
   #             :cleaning,
   #             :info_panel,
-  #             :ground,
   #             :restrictions,
-  #             :risk_areas,
-  #             :water_quality_entity,
-  #             :water_quality_contact,
-  #             :water_contact_email,
-  #             :security_entity,
-  #             :security_entity_contact,
-  #             :security_entity_email,
-  #             :health_authority,
-  #             :health_authority_contact,
-  #             :health_authority_email,
-  #             :municipality,
-  #             :municipality_contact,
-  #             :municipality_email,
   #             :beach_support,
   #             :water_chair,
   #             :construction,

--- a/app/serializers/random_store_serializer.rb
+++ b/app/serializers/random_store_serializer.rb
@@ -45,6 +45,27 @@ class RandomStoreSerializer
   attribute :parking, if: proc { |object| object.beach? } do
     [true, false].sample
   end
+  attribute :garbage_collection, if: proc { |object| object.beach? } do
+    [true, false].sample
+  end
+  attribute :cleaning, if: proc { |object| object.beach? } do
+    [true, false].sample
+  end
+  attribute :info_panel, if: proc { |object| object.beach? } do
+    [true, false].sample
+  end
+  attribute :beach_support, if: proc { |object| object.beach? } do
+    [true, false].sample
+  end
+  attribute :construction, if: proc { |object| object.beach? } do
+    [true, false].sample
+  end
+  attribute :collapsing_risk, if: proc { |object| object.beach? } do
+    [true, false].sample
+  end
+  attribute :bathing_support, if: proc { |object| object.beach? } do
+    [true, false].sample
+  end
   attribute :water_classification, if: proc { |object| object.beach? } do |object|
     object.beach_configuration.water_classification.presence || rand(1..4)
   end

--- a/app/serializers/random_store_serializer.rb
+++ b/app/serializers/random_store_serializer.rb
@@ -63,15 +63,6 @@ class RandomStoreSerializer
   attribute :water_quality_url, if: proc { |object| object.beach? } do |object|
     object.beach_configuration.water_quality_url.presence || 'https://apambiente.pt/'
   end
-  attribute :category, if: proc { |object| object.beach? } do
-    [:ocean, :river].sample
-  end
-  attribute :average_users, if: proc { |object| object.beach? } do
-    rand(10..200)
-  end
-  attribute :parking_spots, if: proc { |object| object.beach? } do
-    rand(10..80)
-  end
   attribute :season_start, if: proc { |object| object.beach? } do
     Date.parse('06/06/2020')
   end

--- a/app/serializers/store_serializer.rb
+++ b/app/serializers/store_serializer.rb
@@ -112,6 +112,12 @@ class StoreSerializer
   attribute :water_chair, if: proc { |object| object.beach? } do |object|
     object.beach_configuration.water_chair || false
   end
+  attribute :construction, if: proc { |object| object.beach? } do |object|
+    object.beach_configuration.construction || false
+  end
+  attribute :collapsing_risk, if: proc { |object| object.beach? } do |object|
+    object.beach_configuration.collapsing_risk || false
+  end
   attribute :bathing_support, if: proc { |object| object.beach? } do |object|
     object.beach_configuration.bathing_support || false
   end

--- a/app/serializers/store_serializer.rb
+++ b/app/serializers/store_serializer.rb
@@ -85,9 +85,6 @@ class StoreSerializer
   attribute :water_quality_updated_at, if: proc { |object| object.beach? } do |object|
     object.beach_configuration.water_quality_updated_at
   end
-  attribute :average_users, if: proc { |object| object.beach? } do |object|
-    object.beach_configuration.average_users
-  end
   attribute :water_quality_url, if: proc { |object| object.beach? } do |object|
     object.beach_configuration.water_quality_url
   end
@@ -100,12 +97,6 @@ class StoreSerializer
   attribute :photo do |object|
     rails_blob_path(object.photo, only_path: true) if object.photo.attached?
   end
-  attribute :category, if: proc { |object| object.beach? } do |object|
-    object.beach_configuration.category
-  end
-  attribute :parking_spots, if: proc { |object| object.beach? } do |object|
-    object.beach_configuration.parking_spots
-  end
   attribute :garbage_collection, if: proc { |object| object.beach? } do |object|
     object.beach_configuration.garbage_collection || false
   end
@@ -114,9 +105,6 @@ class StoreSerializer
   end
   attribute :info_panel, if: proc { |object| object.beach? } do |object|
     object.beach_configuration.info_panel || false
-  end
-  attribute :restaurant, if: proc { |object| object.beach? } do |object|
-    object.beach_configuration.restaurant || false
   end
   attribute :beach_support, if: proc { |object| object.beach? } do |object|
     object.beach_configuration.beach_support || false

--- a/app/views/beaches/_form.html.erb
+++ b/app/views/beaches/_form.html.erb
@@ -127,40 +127,12 @@
       <%= form.fields_for :beach_configuration do |builder| %>
         <div class="form-row">
           <div class="form-group col-md-6">
-            <%= builder.label :category, class: "col-sm-4 col-form-label" %>
-            <%= builder.select :category, enum_options_for_select(BeachConfiguration, :category, true), {}, class: 'form-control' %>
-          </div>
-
-          <div class="form-group col-md-6">
             <%= builder.label :quality_flag, class: "col-sm-4 col-form-label" %>
             <%= builder.check_box :quality_flag,  class: "form-control" %>
           </div>
-        </div>
-        <div class="form-row">
           <div class="form-group col-md-6">
-            <%= builder.label :beach_type, class: "col-sm-4 col-form-label" %>
-            <%= builder.text_field :beach_type, class: "form-control" %>
-          </div>
-
-          <div class="form-group col-md-6">
-            <%= builder.label :ground, class: "col-sm-4 col-form-label" %>
-            <%= builder.text_field :ground,  class: "form-control" %>
-          </div>
-        </div>
-        <div class="form-row">
-          <div class="form-group col-md-4">
-            <%= builder.label :restrictions, class: "col-sm-4 col-form-label" %>
-            <%= builder.text_field :restrictions, class: "form-control" %>
-          </div>
-
-          <div class="form-group col-md-4">
-            <%= builder.label :risk_areas, class: "col-sm-4 col-form-label" %>
-            <%= builder.text_field :risk_areas,  class: "form-control" %>
-          </div>
-
-          <div class="form-group col-md-4">
-            <%= builder.label :average_users, class: "col-sm-6 col-form-label" %>
-            <%= builder.text_field :average_users,  class: "form-control" %>
+            <%= builder.label :sapo_code, class: "col-sm-6 col-form-label" %>
+            <%= builder.text_field :sapo_code,  class: "form-control" %>
           </div>
         </div>
 
@@ -202,23 +174,17 @@
             <%= builder.label :cleaning, class: "col-sm-6 col-form-label" %>
             <%= builder.check_box :cleaning,  class: "form-control" %>
           </div>
-
           <div class="form-group col-md-4">
             <%= builder.label :info_panel, class: "col-sm-6 col-form-label" %>
             <%= builder.check_box :info_panel,  class: "form-control" %>
           </div>
-
-          <div class="form-group col-md-4">
-            <%= builder.label :restaurant, class: "col-sm-4 col-form-label" %>
-            <%= builder.check_box :restaurant,  class: "form-control" %>
-          </div>
-        </div>
-
-        <div class="form-row">
           <div class="form-group col-md-4">
             <%= builder.label :parking, class: "col-sm-4 col-form-label" %>
             <%= builder.check_box :parking,  class: "form-control" %>
           </div>
+        </div>
+
+        <div class="form-row">
           <div class="form-group col-md-4">
             <%= builder.label :beach_support, class: "col-sm-6 col-form-label" %>
             <%= builder.check_box :beach_support,  class: "form-control" %>
@@ -227,12 +193,12 @@
             <%= builder.label :water_chair, class: "col-sm-6 col-form-label" %>
             <%= builder.check_box :water_chair,  class: "form-control" %>
           </div>
-        </div>
-        <div class="form-row">
           <div class="form-group col-md-4">
             <%= builder.label :construction, class: "col-sm-6 col-form-label" %>
             <%= builder.check_box :construction,  class: "form-control" %>
           </div>
+        </div>
+        <div class="form-row">
           <div class="form-group col-md-4">
             <%= builder.label :collapsing_risk, class: "col-sm-6 col-form-label" %>
             <%= builder.check_box :collapsing_risk,  class: "form-control" %>
@@ -241,21 +207,9 @@
             <%= builder.label :bathing_support, class: "col-sm-6 col-form-label" %>
             <%= builder.check_box :bathing_support,  class: "form-control" %>
           </div>
-        </div>
-        <div class="form-row">
-          <div class="form-group col-md-4">
-            <%= builder.label :parking_spots, class: "col-sm-8 col-form-label" %>
-            <%= builder.text_field :parking_spots,  class: "form-control" %>
-          </div>
-
           <div class="form-group col-md-4">
             <%= builder.label :water_classification, class: "col-sm-8 col-form-label" %>
             <%= builder.text_field :water_classification,  class: "form-control" %>
-          </div>
-
-          <div class="form-group col-md-4">
-            <%= builder.label :sapo_code, class: "col-sm-6 col-form-label" %>
-            <%= builder.text_field :sapo_code,  class: "form-control" %>
           </div>
         </div>
       <% end %>

--- a/app/views/beaches/show.html.erb
+++ b/app/views/beaches/show.html.erb
@@ -110,30 +110,6 @@
       <div class="card">
         <div class="card-body">
           <p>
-            <strong><%= BeachConfiguration.human_attribute_name(:category) %></strong>
-            <%= b_config.category %>
-          </p>
-          <p>
-            <strong><%= BeachConfiguration.human_attribute_name(:beach_type) %></strong>
-            <%= b_config.beach_type %>
-          </p>
-          <p>
-            <strong><%= BeachConfiguration.human_attribute_name(:ground) %></strong>
-            <%= b_config.ground %>
-          </p>
-          <p>
-            <strong><%= BeachConfiguration.human_attribute_name(:restrictions) %></strong>
-            <%= b_config.restrictions %>
-          </p>
-          <p>
-            <strong><%= BeachConfiguration.human_attribute_name(:risk_areas) %></strong>
-            <%= b_config.risk_areas %>
-          </p>
-          <p>
-            <strong><%= BeachConfiguration.human_attribute_name(:average_users) %></strong>
-            <%= b_config.average_users %>
-          </p>
-          <p>
             <strong><%= BeachConfiguration.human_attribute_name(:guarded) %></strong>
             <%= b_config.guarded %>
           </p>
@@ -202,14 +178,6 @@
           <p>
             <strong><%= BeachConfiguration.human_attribute_name(:info_panel) %></strong>
             <%= b_config.info_panel %>
-          </p>
-          <p>
-            <strong><%= BeachConfiguration.human_attribute_name(:restaurant) %></strong>
-            <%= b_config.restaurant %>
-          </p>
-          <p>
-            <strong><%= BeachConfiguration.human_attribute_name(:parking_spots) %></strong>
-            <%= b_config.parking_spots %>
           </p>
           <p>
             <strong><%= BeachConfiguration.human_attribute_name(:water_chair) %></strong>

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -68,12 +68,6 @@ pt:
       user_store:
         approved: 'Aprovada?'
       beach_configuration:
-        category: 'Categoria'
-        beach_type: 'Tipo de praia'
-        ground: 'Terreno'
-        restrictions: 'Restrições'
-        risk_areas: 'Áreas de risco'
-        average_users: 'Média de utilizadores'
         guarded: 'Vigiada'
         first_aid_station: 'Posto primeiros socorros'
         wc: 'Sanitários'
@@ -82,9 +76,7 @@ pt:
         garbage_collection: 'Recolha de lixo'
         cleaning: 'Limpeza de praia'
         info_panel: 'Painel informativo'
-        restaurant: 'Bar/restaurante'
         parking: 'Estacionamento'
-        parking_spots: 'Lugares de estacionamento'
         season_start: 'Início época balnear'
         season_end: 'Fim época balnear'
         water_quality: 'Qualidade da água'

--- a/db/migrate/20200624110119_remove_deco_attributes_from_beach_configuration.rb
+++ b/db/migrate/20200624110119_remove_deco_attributes_from_beach_configuration.rb
@@ -1,0 +1,24 @@
+class RemoveDecoAttributesFromBeachConfiguration < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :beach_configurations, :ground, :string
+    remove_column :beach_configurations, :restrictions, :string
+    remove_column :beach_configurations, :beach_type, :string
+    remove_column :beach_configurations, :category, :integer
+    remove_column :beach_configurations, :risk_areas, :string
+    remove_column :beach_configurations, :average_users, :integer
+    remove_column :beach_configurations, :restaurant, :boolean
+    remove_column :beach_configurations, :parking_spots, :integer
+    remove_column :beach_configurations, :water_quality_entity, :string
+    remove_column :beach_configurations, :water_quality_contact, :string
+    remove_column :beach_configurations, :water_contact_email, :string
+    remove_column :beach_configurations, :security_entity, :string
+    remove_column :beach_configurations, :security_entity_contact, :string
+    remove_column :beach_configurations, :security_entity_email, :string
+    remove_column :beach_configurations, :health_authority, :string
+    remove_column :beach_configurations, :health_authority_contact, :string
+    remove_column :beach_configurations, :health_authority_email, :string
+    remove_column :beach_configurations, :municipality, :string
+    remove_column :beach_configurations, :municipality_contact, :string
+    remove_column :beach_configurations, :municipality_email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_12_151148) do
+ActiveRecord::Schema.define(version: 2020_06_24_110119) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,12 +51,6 @@ ActiveRecord::Schema.define(version: 2020_06_12_151148) do
   end
 
   create_table "beach_configurations", force: :cascade do |t|
-    t.integer "category"
-    t.string "beach_type"
-    t.string "ground"
-    t.string "restrictions"
-    t.string "risk_areas"
-    t.integer "average_users"
     t.boolean "guarded"
     t.boolean "first_aid_station"
     t.boolean "wc"
@@ -65,26 +59,12 @@ ActiveRecord::Schema.define(version: 2020_06_12_151148) do
     t.boolean "garbage_collection"
     t.boolean "cleaning"
     t.boolean "info_panel"
-    t.boolean "restaurant"
     t.boolean "parking"
-    t.integer "parking_spots"
     t.date "season_start"
     t.date "season_end"
     t.integer "water_quality"
     t.string "water_quality_url"
     t.boolean "quality_flag"
-    t.string "water_quality_entity"
-    t.string "water_quality_contact"
-    t.string "water_contact_email"
-    t.string "security_entity"
-    t.string "security_entity_contact"
-    t.string "security_entity_email"
-    t.string "health_authority"
-    t.string "health_authority_contact"
-    t.string "health_authority_email"
-    t.string "municipality"
-    t.string "municipality_contact"
-    t.string "municipality_email"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "store_id"
@@ -98,8 +78,6 @@ ActiveRecord::Schema.define(version: 2020_06_12_151148) do
     t.datetime "water_quality_updated_at"
     t.integer "water_classification"
     t.string "sapo_code"
-    t.index ["average_users"], name: "index_beach_configurations_on_average_users"
-    t.index ["category"], name: "index_beach_configurations_on_category"
     t.index ["guarded"], name: "index_beach_configurations_on_guarded"
     t.index ["parking"], name: "index_beach_configurations_on_parking"
     t.index ["quality_flag"], name: "index_beach_configurations_on_quality_flag"


### PR DESCRIPTION
This PR removes old attributes that came from DECO importer and that are not relevant for the final version of beaches used by APA.

It also updates the API responses to ensure we are showing all relevant attributes for beaches, which are:

* guarded <> Vigiada
* first-aid-station <> Posto de primeiros socorros
* wc <> Sanitários
* showers <> Duche
* accessibility <> Acessível
* garbage-collection <> Recolha de lixo
* cleaning <> Limpeza de praia
* info-panel <> Painel Informativo
* parking <> Estacionamento
* beach-support <> Apoio de Praia (aka: Bar/Restaurante)
* water-chair <> Cadeira anfíbia
* construction <> Obras em curso
* collapsing-risk <> Risco de derrocada
* bathing-support <> Apoio Balnear
* quality-flag <> Bandeira Azul
* season-start <> Início época balnear
* season-end <> Fim época balnear
* water-quality <> Qualidade da água (nota: última medição)
* water-quality-url <> Link para qualidade da água
* water-quality-updated-at <> Data última actualização da qualidade da água
