### PR TITLE
Use valid_until instead of updated_time for the quick status reports

### DIFF
--- a/app/models/status_crowdsource_user.rb
+++ b/app/models/status_crowdsource_user.rb
@@ -24,7 +24,7 @@ class StatusCrowdsourceUser < ApplicationRecord
 
   def update_status_crowdsource
     # TODO: This is hardcoded. It should be somewhere else (and synched with the front)
-    return if StatusGeneral.where(store_id: store_id).where('updated_time > ?', Time.current - 1.hour).any?
+    return if StatusGeneral.where(store_id: store_id).where('valid_until < ?', Time.current).any?
 
     StatusCrowdsource.find_by(store_id: store_id).update(updated_time: Time.current, status: status, voters: 1)
     StatusGeneral.find_by(store_id: store_id).update(updated_time: Time.current,


### PR DESCRIPTION
We are now always updating the valid_until time, so we can use that
instead of updated_time to check if a new user report should be
considered straight away.