### PR TITLE
Updates response format with badges

### DIFF
--- a/app/controllers/api/v1/auth_controller.rb
+++ b/app/controllers/api/v1/auth_controller.rb
@@ -46,7 +46,7 @@ module Api
           User.where.not(id: user.id).where(app_uuid: user.app_uuid).update_all(app_uuid: nil)
           random_badges_for(user) unless Rails.env.production?
           options = {}
-          options[:include] = [:stores, :user_badges]
+          options[:include] = [:stores]
           # rubocop:enable Rails/SkipsModelValidations
           render json: UserSerializer.new(user, options).serialized_json, status: :ok
         else

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -16,9 +16,7 @@ module Api
 
       def index
         random_badges_for(@user) unless Rails.env.production?
-        options = {}
-        options[:include] = [:user_badges]
-        render json: UserSerializer.new(@user, options).serialized_json
+        render json: UserSerializer.new(@user).serialized_json
       end
 
       # TODO

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -54,7 +54,7 @@ class UserSerializer
 
   Badge.order(:slug).each do |badge|
     attribute "badge_#{badge.slug}".to_sym do |object|
-      object.badges.include?(badge)
+      UserBadge.find_by(user_id: object.id, badge_id: badge.id).present?
     end
   end
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -51,5 +51,10 @@ class UserSerializer
   end
 
   has_many :stores, type: :stores, serializer: StoreSerializer
-  has_many :user_badges, type: :badges, serializer: UserBadgeSerializer
+
+  Badge.order(:slug).each do |badge|
+    attribute "badge_#{badge.slug}".to_sym do |object|
+      object.badges.include?(badge)
+    end
+  end
 end


### PR DESCRIPTION
Now badges are included in the response as boolean attributes of the user record, instead of included records. True if the user got that badge, false otherwise.

You can test with both the `POST /login` and `GET /users` endpoints.

Badges come in the format `badge-{slug}`.

Wondering if the method I'm using is the quickest to check if it exists. maybe we need an index.